### PR TITLE
ci: use cancle-build feature from github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: lint-unit
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 on:
     push:
         branches:
@@ -10,12 +14,6 @@ jobs:
     lint-unit:
         runs-on: ubuntu-latest
         steps:
-            - name: cancel-previous-run
-              uses: styfle/cancel-workflow-action@0.9.1
-              with:
-                  all_but_latest: true
-                  access_token: ${{ secrets.GITHUB_TOKEN }}
-
             - name: checkout
               uses: actions/checkout@v3
               with:


### PR DESCRIPTION
use `cancel-build` feature from github. Drop the use of third party gh action