### PR TITLE
ci: move dependabot config to .github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
       commit-message:
           # Prefix all commit messages with "chore: "
           prefix: "chore"
+      reviewers:
+          - saw-jan


### PR DESCRIPTION
move dependabot config to the correct location i.e. `.github`