### PR TITLE
fix: add dependabot required config property

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
     - package-ecosystem: "npm"
       directory: "/"
+      schedule:
+          interval: weekly
       commit-message:
           # Prefix all commit messages with "chore: "
           prefix: "chore"


### PR DESCRIPTION
Added dependabot required config property.

Fix for:
```bash
The property '#/updates/0' did not contain a required property of 'schedule'
```