### PR TITLE
test: disable commit length limit rules

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,8 @@
 module.exports = {
     extends: ["@commitlint/config-conventional"],
+    rules: {
+        "body-max-line-length": [0],
+        "footer-max-line-length": [0],
+        "header-max-length": [0],
+    },
 };


### PR DESCRIPTION
disbale commitlint rules to allow more characters in the commit message
```
"body-max-line-length"
"footer-max-line-length"
"header-max-length"
```