### PR TITLE
fix: incorrect doc string indentation

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -87,7 +87,6 @@ module.exports = class Indentation extends Rule {
             lines[++lineIndex] = problem.fixData.indent + line;
         }
         // fix last delimiter
-        // eslint-disable-next-line quotes
         lines[++lineIndex] =
             problem.fixData.indent + problem.fixData.ast.delimiter;
 

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -79,15 +79,17 @@ module.exports = class Indentation extends Rule {
         const startLineIndex = problem.location.line - 1;
         const startLine = lines[startLineIndex].trim();
         lines[startLineIndex] = problem.fixData.indent + startLine;
-        let endLineIndex = startLineIndex;
+        let lineIndex = startLineIndex;
 
-        for (const line of lines.slice(startLineIndex + 1)) {
-            lines[++endLineIndex] = problem.fixData.indent + line.trimStart();
-            // eslint-disable-next-line quotes
-            if (startLine.startsWith('"""') && line.trim().startsWith('"""')) {
-                break;
-            }
+        const docContent = problem.fixData.ast.content.split("\n");
+
+        for (const line of docContent) {
+            lines[++lineIndex] = problem.fixData.indent + line;
         }
+        // fix last delimiter
+        // eslint-disable-next-line quotes
+        lines[++lineIndex] =
+            problem.fixData.indent + problem.fixData.ast.delimiter;
 
         return lines.join("\n");
     }
@@ -99,7 +101,7 @@ module.exports = class Indentation extends Rule {
         return this.fixSingleLine;
     }
 
-    #verify({ keyword, location }) {
+    #verify({ keyword, location, ast }) {
         keyword = keyword.trim();
         const expectedIndent = getIndentation(
             keyword,
@@ -120,6 +122,7 @@ module.exports = class Indentation extends Rule {
                 ),
                 fixData: {
                     indent: " ".repeat(expectedIndent),
+                    ast,
                 },
                 applyFix: this.#getFixMethodForKeyword(keyword),
             });
@@ -167,6 +170,7 @@ module.exports = class Indentation extends Rule {
             this.#verify({
                 keyword: "DocString",
                 location: step.docString.location,
+                ast: step.docString,
             });
         }
 

--- a/tests/lib/rules/indentation.test.js
+++ b/tests/lib/rules/indentation.test.js
@@ -35,7 +35,7 @@ describe("Indentation rule", () => {
 
     describe("invalid indentation", () => {
         const testData = getInvalidTestData().filter(
-            (test) => test[4] !== true
+            (test) => test[4] !== true // get test data except docstring
         );
 
         it.each(testData)("%s", (_, text, expectedProblems) => {
@@ -58,26 +58,65 @@ describe("Indentation rule", () => {
             });
         });
 
-        // TODO: need a fix
-        // docString indentation tests
-        describe("Failing", () => {
-            const failingTestData = getInvalidTestData().filter(
+        describe("DocString", () => {
+            const testData = getInvalidTestData().filter(
                 (test) => test[4] === true // get all docstring test data
             );
-            failingTestData.forEach((test) => {
-                it.failing(test[0], () => {
-                    const ast = parser.parse(test[1]);
-                    const problems = Indentation.run(ast, config);
+            testData.forEach((test, index) => {
+                // first test case passes
+                if (index === 0) {
+                    it(test[0], () => {
+                        const ast = parser.parse(test[1]);
+                        const problems = Indentation.run(ast, config);
 
-                    expect(problems.length).toEqual(test[2].length);
-                    problems.forEach((problem, index) => {
-                        expect(problem.location).toEqual(
-                            test[2][index].location
-                        );
-                        expect(problem.message).toEqual(test[2][index].message);
+                        expect(problems.length).toEqual(test[2].length);
+                        problems.forEach((problem, index) => {
+                            expect(problem.location).toEqual(
+                                test[2][index].location
+                            );
+                            expect(problem.message).toEqual(
+                                test[2][index].message
+                            );
+                            expect(problem.applyFix).toBeInstanceOf(Function);
+                            expect(problem.fixData.indent).toEqual(
+                                test[2][index].fixData.indent
+                            );
+                            expect(problem.fixData.ast).toHaveProperty(
+                                "content"
+                            );
+                            expect(problem.fixData.ast).toHaveProperty(
+                                "delimiter"
+                            );
+                        });
                     });
-                    expect(new Set(problems)).toEqual(new Set(test[2]));
-                });
+                } else {
+                    // TODO: after the issue is fixed, remove the if-block
+                    // https://github.com/gherlint/gherlint/issues/19
+                    it.failing(test[0], () => {
+                        const ast = parser.parse(test[1]);
+                        const problems = Indentation.run(ast, config);
+
+                        expect(problems.length).toEqual(test[2].length);
+                        problems.forEach((problem, index) => {
+                            expect(problem.location).toEqual(
+                                test[2][index].location
+                            );
+                            expect(problem.message).toEqual(
+                                test[2][index].message
+                            );
+                            expect(problem.applyFix).toBeInstanceOf(Function);
+                            expect(problem.fixData.indent).toEqual(
+                                test[2][index].fixData.indent
+                            );
+                            expect(problem.fixData.ast).toHaveProperty(
+                                "content"
+                            );
+                            expect(problem.fixData.ast).toHaveProperty(
+                                "delimiter"
+                            );
+                        });
+                    });
+                }
             });
         });
     });


### PR DESCRIPTION
## Description
Use docstring content from ast and do not trim line spaces to apply the indent correctly

## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/75

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
