### PR TITLE
feat(rule): add new rule 'no_trailing_whitespace'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   New lint rule `no_trailing_whitespace` - checks trailing whitespaces (https://github.com/gherlint/gherlint/pull/86)
 -   New lint rule `require_step` - ensures that a Background or a Scenario has at least one step (https://github.com/gherlint/gherlint/pull/88)
 -   Show elapsed times for linting and command execution (https://github.com/gherlint/gherlint/pull/82)
 -   Successful linting now shows a success message (https://github.com/gherlint/gherlint/pull/81)

--- a/lib/config/gherlintrc.js
+++ b/lib/config/gherlintrc.js
@@ -21,5 +21,6 @@ module.exports = {
         indentation: ["error", 2],
         no_repetitive_step_keyword: "error",
         require_step: "error",
+        no_trailing_whitespace: "error",
     },
 };

--- a/lib/linter/Linter.js
+++ b/lib/linter/Linter.js
@@ -85,7 +85,13 @@ module.exports = class Linter {
 
     parseAst(text) {
         try {
-            return this.astParser.parse(text);
+            const ast = this.astParser.parse(text);
+
+            // add the text to the ast
+            // some rules might need it
+            ast.text = text;
+
+            return ast;
         } catch (error) {
             // throw first error
             throw error.errors[0];

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -5,5 +5,6 @@ module.exports = {
         indentation: require("./indentation"),
         no_repetitive_step_keyword: require("./no_repetitive_step_keyword"),
         require_step: require("./require_step"),
+        no_trailing_whitespace: require("./no_trailing_whitespace"),
     },
 };

--- a/lib/rules/no_trailing_whitespace.js
+++ b/lib/rules/no_trailing_whitespace.js
@@ -10,6 +10,8 @@ module.exports = class NoTrailingWhitespace extends Rule {
 
     // Rule entry point
     static run(ast, config) {
+        if (!ast?.text) return [];
+
         const problems = [];
         let lineIndex = 0;
         for (const line of ast.text.split("\n")) {

--- a/lib/rules/no_trailing_whitespace.js
+++ b/lib/rules/no_trailing_whitespace.js
@@ -1,0 +1,42 @@
+const Rule = require("./Rule");
+
+module.exports = class NoTrailingWhitespace extends Rule {
+    static meta = {
+        ruleId: "no_trailing_whitespace",
+        message: "No trailing whitespaces",
+        type: "error", // (warn | error | off)
+        hasFix: true, // (true | false) - if the rule has a fixer or not
+    };
+
+    // Rule entry point
+    static run(ast, config) {
+        const problems = [];
+        let lineIndex = 0;
+        for (const line of ast.text.split("\n")) {
+            lineIndex++;
+            const match = line.match(/\s+$/);
+            if (match !== null) {
+                const location = { line: lineIndex, column: match.index + 1 };
+                problems.push({
+                    ...NoTrailingWhitespace.meta,
+                    type: config.type,
+                    location,
+                    applyFix: NoTrailingWhitespace.fixTrailingWhitespace,
+                });
+            }
+        }
+        return problems;
+    }
+
+    static fixTrailingWhitespace(text, problem) {
+        const lines = text.split("\n");
+        const {
+            location: { line },
+        } = problem;
+
+        const lineText = lines[line - 1];
+        lines[line - 1] = lineText.trimEnd();
+
+        return lines.join("\n");
+    }
+};

--- a/tests/__fixtures__/Rules/no_trailing_whitespace/fixture.js
+++ b/tests/__fixtures__/Rules/no_trailing_whitespace/fixture.js
@@ -1,0 +1,96 @@
+const generator = require("../../../helpers/problemGenerator");
+const NoTrailingWhitespace = require("../../../../lib/rules/no_trailing_whitespace");
+
+function generateProblem(location) {
+    return generator(
+        NoTrailingWhitespace,
+        location,
+        NoTrailingWhitespace.meta.message,
+        {
+            applyFix: jest.fn(),
+        }
+    );
+}
+
+function getValidTestData() {
+    return [
+        [
+            "should show no problems",
+            `Feature: a feature file
+
+  Background: a background
+    Given a step
+
+  Scenario: a scenario
+    When a step
+`,
+            [],
+        ],
+    ];
+}
+function getInvalidTestData() {
+    return [
+        [
+            "should show problems",
+            `Feature: a feature file 
+
+  Background: a background  
+    Given a step    
+    `,
+            [
+                generateProblem({ line: 1, column: 24 }),
+                generateProblem({ line: 3, column: 27 }),
+                generateProblem({ line: 4, column: 17 }),
+                generateProblem({ line: 5, column: 1 }),
+            ],
+        ],
+    ];
+}
+
+function getInvalidTestDataWithFix() {
+    return [
+        [
+            "trailing whitespace in: keyword",
+            "Feature: a feature file   ",
+            generateProblem({ line: 1 }),
+            "Feature: a feature file",
+        ],
+        [
+            "trailing whitespace in: description",
+            `Feature: a feature file
+As a user            
+`,
+            generateProblem({ line: 2 }),
+            `Feature: a feature file
+As a user
+`,
+        ],
+        [
+            "trailing whitespace in: comment",
+            `# comment line      
+Feature: a feature file
+`,
+            generateProblem({ line: 1 }),
+            `# comment line
+Feature: a feature file
+`,
+        ],
+        [
+            "trailing whitespace in: new line",
+            `Feature: a feature file
+      
+  Background: a background`,
+            generateProblem({ line: 2 }),
+            `Feature: a feature file
+
+  Background: a background`,
+        ],
+    ];
+}
+
+module.exports = {
+    generateProblem,
+    getValidTestData,
+    getInvalidTestData,
+    getInvalidTestDataWithFix,
+};

--- a/tests/lib/rules/no_trailing_whitespace.test.js
+++ b/tests/lib/rules/no_trailing_whitespace.test.js
@@ -11,6 +11,18 @@ const config = {
 };
 
 describe("no_trailing_whitespace", () => {
+    describe("invalid text property", () => {
+        it.each([
+            ["null", null],
+            ["undefined", undefined],
+            ["empty", ""],
+        ])("%s", (_, textValue) => {
+            const ast = { text: textValue };
+            const problems = NoTrailingWhitespace.run(ast, config);
+            expect(problems).toEqual([]);
+        });
+    });
+
     describe("no trailing whitespaces", () => {
         const testData = getValidTestData();
         it.each(testData)("%s", (_, text, expectedProblems) => {

--- a/tests/lib/rules/no_trailing_whitespace.test.js
+++ b/tests/lib/rules/no_trailing_whitespace.test.js
@@ -1,0 +1,54 @@
+const parser = require("../../helpers/parser");
+const {
+    getValidTestData,
+    getInvalidTestData,
+    getInvalidTestDataWithFix,
+} = require("../../__fixtures__/Rules/no_trailing_whitespace/fixture");
+const NoTrailingWhitespace = require("../../../lib/rules/no_trailing_whitespace");
+
+const config = {
+    type: "error",
+};
+
+describe("no_trailing_whitespace", () => {
+    describe("no trailing whitespaces", () => {
+        const testData = getValidTestData();
+        it.each(testData)("%s", (_, text, expectedProblems) => {
+            const ast = parser.parse(text);
+            ast.text = text;
+            const problems = NoTrailingWhitespace.run(ast, config);
+            expect(problems).toEqual(expectedProblems);
+            expect(problems.length).toEqual(0);
+        });
+    });
+
+    describe("some trailing whitespaces", () => {
+        const testData = getInvalidTestData();
+        it.each(testData)("%s", (_, text, expectedProblems) => {
+            const ast = parser.parse(text);
+            ast.text = text;
+            const problems = NoTrailingWhitespace.run(ast, config);
+            expect(problems.length).toEqual(expectedProblems.length);
+            problems.forEach((problem, index) => {
+                expect(problem.location).toEqual(
+                    expectedProblems[index].location
+                );
+                expect(problem.message).toEqual(
+                    expectedProblems[index].message
+                );
+                expect(problem.applyFix).toBeInstanceOf(Function);
+            });
+        });
+    });
+
+    describe("method: fixTrailingWhitespace", () => {
+        const testData = getInvalidTestDataWithFix();
+        it.each(testData)("%s", (_, text, problem, expectedFixedText) => {
+            const fixedText = NoTrailingWhitespace.fixTrailingWhitespace(
+                text,
+                problem
+            );
+            expect(fixedText).toEqual(expectedFixedText);
+        });
+    });
+});


### PR DESCRIPTION
## Description
🎉 New Rule Added: `no_trailing_whitespace`

Rule metadata:
```js
meta = {
    ruleId: "no_trailing_whitespace",
    type: "error"
}
```

![Screenshot from 2024-04-22 22-19-03](https://github.com/gherlint/gherlint/assets/52366632/6490ce0f-330b-47dc-b835-f735dc9f8054)

## Related Issue
- Part of https://github.com/gherlint/gherlint/issues/17

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [ ] Documentation updated
