### PR TITLE
feat(rule): add new rule 'no_then_as_first_step'

### DIFF
--- a/lib/config/gherlintrc.js
+++ b/lib/config/gherlintrc.js
@@ -23,5 +23,6 @@ module.exports = {
         require_step: "error",
         no_trailing_whitespace: "error",
         require_scenario: "error",
+        no_then_as_first_step: "warn",
     },
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -7,5 +7,6 @@ module.exports = {
         require_step: require("./require_step"),
         no_trailing_whitespace: require("./no_trailing_whitespace"),
         require_scenario: require("./require_scenario"),
+        no_then_as_first_step: require("./no_then_as_first_step"),
     },
 };

--- a/lib/rules/no_then_as_first_step.js
+++ b/lib/rules/no_then_as_first_step.js
@@ -1,0 +1,59 @@
+const { isEmpty: _isEmpty, has: _has, keys: _keys } = require("lodash");
+const Rule = require("./Rule");
+
+module.exports = class NoThenAsFirstStep extends Rule {
+    /**
+     * Rule filename and RuleId MUST follow snake_case convention
+     */
+    static meta = {
+        ruleId: "no_then_as_first_step",
+        message: "First step should not be a 'Then' step",
+        type: "warn",
+        location: {},
+        hasFix: false,
+    };
+
+    constructor(ast, config) {
+        super(ast, config);
+    }
+
+    // Rule entry point
+    static run(ast, config) {
+        if (_isEmpty(ast?.feature)) return [];
+
+        return new NoThenAsFirstStep(ast, config).execute();
+    }
+
+    execute() {
+        this.checkFirstStep(this._ast);
+
+        return this.getProblems();
+    }
+
+    checkFirstStep(astObject) {
+        const keyword = _keys(astObject).shift();
+
+        if (["background", "scenario"].includes(keyword)) {
+            if (astObject[keyword].steps.length === 0) {
+                return;
+            }
+
+            // get the first step
+            const firstStep = astObject[keyword].steps[0];
+            if (firstStep.keyword.trim() === "Then") {
+                this.storeLintProblem({
+                    ...NoThenAsFirstStep.meta,
+                    type: this._config.type,
+                    location: firstStep.location,
+                });
+            }
+            return;
+        }
+
+        if (_has(astObject[keyword], "children")) {
+            for (const child of astObject[keyword].children) {
+                this.checkFirstStep(child);
+            }
+        }
+    }
+};

--- a/tests/__fixtures__/Rules/no_then_as_first_step/fixture.js
+++ b/tests/__fixtures__/Rules/no_then_as_first_step/fixture.js
@@ -1,0 +1,223 @@
+const generator = require("../../../helpers/problemGenerator");
+const NoThenAsFirstStep = require("../../../../lib/rules/no_then_as_first_step");
+
+function generateProblem(location) {
+    return generator(
+        NoThenAsFirstStep,
+        location,
+        NoThenAsFirstStep.meta.message
+    );
+}
+
+function getValidTestData() {
+    return [
+        [
+            "with Rule: Background",
+            `Feature: a feature file
+  Rule: a rule
+    Background: a background
+      Given a step`,
+            [],
+        ],
+        [
+            "with Rule: Scenario",
+            `Feature: a feature file
+  Rule: a rule
+    Scenario: a scenario
+      Given a step`,
+            [],
+        ],
+        [
+            "with Rule: Scenario Outline",
+            `Feature: a feature file
+  Rule: a rule
+    Scenario Outline: a scenario outline
+      Given a step`,
+            [],
+        ],
+        [
+            "with Rule: multiple scenarios",
+            `Feature: a feature file
+  Rule: a rule
+    Background: a background
+      Given a step
+    Scenario: a scenario
+      Given a step
+    Scenario Outline: a scenario outline
+      Given a step`,
+            [],
+        ],
+        [
+            "with Rule: multiple steps",
+            `Feature: a feature file
+  Rule: a rule
+    Background: a background
+      Given a step
+      Then a step
+    Scenario: a scenario
+      Given a step
+      When a step
+      Then a step
+    Scenario Outline: a scenario outline
+      Given a step
+      Then a step`,
+            [],
+        ],
+        [
+            "without Rule: Background",
+            `Feature: a feature file
+  Background: a background
+    Given a step`,
+            [],
+        ],
+        [
+            "without Rule: Scenario",
+            `Feature: a feature file
+  Scenario: a scenario
+    When a step`,
+            [],
+        ],
+        [
+            "without Rule: Scenario Outline",
+            `Feature: a feature file
+  Scenario Outline: a scenario
+    When a step`,
+            [],
+        ],
+        [
+            "without Rule: multiple scenarios",
+            `Feature: a feature file
+  Background: a background
+    Given a step
+  Scenario: a scenario
+    When a step
+  Scenario Outline: a scenario outline
+    When a step`,
+            [],
+        ],
+        [
+            "without Rule: multiple steps",
+            `Feature: a feature file
+  Scenario: a scenario
+    Given a step
+    When a step
+    Then a step
+  Scenario: a scenario
+    When a step
+    Then a step`,
+            [],
+        ],
+        [
+            "with Rule: no scenarios",
+            `Feature: a feature file
+  Rule: a rule`,
+            [],
+        ],
+        ["without Rule: no scenarios", "Feature: a feature file", []],
+        [
+            "without Rule: no steps",
+            `Feature: a feature file
+  Scenario: a scenario`,
+            [],
+        ],
+    ];
+}
+
+function getInvalidTestData() {
+    return [
+        [
+            "with Rule: Background",
+            `Feature: a feature file
+  Rule: a rule
+    Background: a background
+      Then a step`,
+            [generateProblem({ line: 4, column: 7 })],
+        ],
+        [
+            "with Rule: Scenario",
+            `Feature: a feature file
+  Rule: a rule
+    Scenario: a scenario
+      Then a step`,
+            [generateProblem({ line: 4, column: 7 })],
+        ],
+        [
+            "with Rule: Scenario Outline",
+            `Feature: a feature file
+  Rule: a rule
+    Scenario Outline: a scenario outline
+      Then a step`,
+            [generateProblem({ line: 4, column: 7 })],
+        ],
+        [
+            "with Rule: multiple scenarios",
+            `Feature: a feature file
+  Rule: a rule
+    Background: a background
+      Then a step
+    Scenario: a scenario
+      Then a step
+    Scenario Outline: a scenario outline
+      Then a step`,
+            [
+                generateProblem({ line: 4, column: 7 }),
+                generateProblem({ line: 6, column: 7 }),
+                generateProblem({ line: 8, column: 7 }),
+            ],
+        ],
+        [
+            "without Rule: Background",
+            `Feature: a feature file
+  Background: a background
+    Then a step`,
+            [generateProblem({ line: 3, column: 5 })],
+        ],
+        [
+            "without Rule: Scenario",
+            `Feature: a feature file
+  Scenario: a scenario
+    Then a step`,
+            [generateProblem({ line: 3, column: 5 })],
+        ],
+        [
+            "without Rule: Scenario Outline",
+            `Feature: a feature file
+  Scenario Outline: a scenario outline
+    Then a step`,
+            [generateProblem({ line: 3, column: 5 })],
+        ],
+        [
+            "without Rule: multiple scenarios",
+            `Feature: a feature file
+  Background: a background
+    Then a step
+  Scenario: a scenario
+    Then a step
+  Scenario Outline: a scenario outline
+    Then a step`,
+            [
+                generateProblem({ line: 3, column: 5 }),
+                generateProblem({ line: 5, column: 5 }),
+                generateProblem({ line: 7, column: 5 }),
+            ],
+        ],
+        [
+            "without Rule: valid and invalid",
+            `Feature: a feature file
+  Background: a background
+    Given a step
+  Scenario: a scenario
+    When a step
+    Then a step
+  Scenario: a scenario
+    Then a step`,
+            [generateProblem({ line: 8, column: 5 })],
+        ],
+    ];
+}
+
+module.exports = {
+    generateProblem,
+    getValidTestData,
+    getInvalidTestData,
+};

--- a/tests/lib/rules/no_then_as_first_step.test.js
+++ b/tests/lib/rules/no_then_as_first_step.test.js
@@ -1,0 +1,53 @@
+const parser = require("../../helpers/parser");
+const {
+    getValidTestData,
+    getInvalidTestData,
+} = require("../../__fixtures__/Rules/no_then_as_first_step/fixture");
+const NoThenAsFirstStep = require("../../../lib/rules/no_then_as_first_step");
+
+const config = {
+    type: "warn",
+};
+
+describe("no_then_as_first_step", () => {
+    describe("invalid ast", () => {
+        it.each([
+            ["undefined", undefined],
+            ["null", null],
+            ["string", ""],
+            ["empty object", {}],
+        ])("%s: should not show any lint problems", (_, ast) => {
+            const problems = NoThenAsFirstStep.run(ast);
+            expect(problems).toEqual([]);
+        });
+    });
+
+    describe("Valid: Given/When as first step", () => {
+        const testData = getValidTestData();
+
+        it.each(testData)("%s", (_, text, expectedProblems) => {
+            const ast = parser.parse(text);
+            const problems = NoThenAsFirstStep.run(ast, config);
+            expect(problems).toEqual(expectedProblems);
+            expect(problems.length).toEqual(0);
+        });
+    });
+
+    describe("Invalid: Then as first step", () => {
+        const testData = getInvalidTestData();
+
+        it.each(testData)("%s", (_, text, expectedProblems) => {
+            const ast = parser.parse(text);
+            const problems = NoThenAsFirstStep.run(ast, config);
+            expect(problems.length).toEqual(expectedProblems.length);
+            problems.forEach((problem, index) => {
+                expect(problem.location).toEqual(
+                    expectedProblems[index].location
+                );
+                expect(problem.message).toEqual(
+                    expectedProblems[index].message
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
🎉 New Rule Added: `no_then_as_first_step`

Rule metadata:
```js
meta = {
    ruleId: "no_then_as_first_step",
    type: "warn"
}
```

![Screenshot from 2024-04-29 21-46-43](https://github.com/gherlint/gherlint/assets/52366632/b8c0d673-8af4-40b0-8fb1-efe4ffb63f6e)

## Related Issue
- Part of https://github.com/gherlint/gherlint/issues/17

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [ ] Documentation updated
