### PR TITLE
refactor(rule): return early if already checking Background/Scenario

### DIFF
--- a/lib/rules/require_step.js
+++ b/lib/rules/require_step.js
@@ -46,6 +46,7 @@ module.exports = class RequireStep extends Rule {
                     location: astObject[keyword].location,
                 });
             }
+            return;
         }
 
         if (_has(astObject[keyword], "children")) {


### PR DESCRIPTION
## Description
Do early return and do not try to check children property if already in `Background/Scneario` ast object

## Related Issue


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)
- [x] Improvement/Performance

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Documentation updated
