### PR TITLE
fix: error with NaN when indentation value is not provided

### DIFF
--- a/lib/config/gherlintrc.js
+++ b/lib/config/gherlintrc.js
@@ -18,7 +18,7 @@ module.exports = {
      * - off
      */
     rules: {
-        indentation: ["error", 2],
+        indentation: "error",
         no_repetitive_step_keyword: "error",
         require_step: "error",
         no_trailing_whitespace: "error",

--- a/lib/gherlint/GherlintConfig.js
+++ b/lib/gherlint/GherlintConfig.js
@@ -156,20 +156,9 @@ module.exports = class GherlintConfig {
         const mergedRules = {};
         keys(userConfig.rules || {}).forEach((rule) => {
             if (typeof userConfig.rules[rule] === "string") {
-                mergedRules[rule] = [
-                    userConfig.rules[rule],
-                    this.getDefaultConfig().rules[rule][1],
-                ];
-            } else if (userConfig.rules[rule].length === 1) {
-                mergedRules[rule] = [
-                    userConfig.rules[rule][0],
-                    this.getDefaultConfig().rules[rule][1],
-                ];
+                mergedRules[rule] = userConfig.rules[rule];
             } else {
-                mergedRules[rule] = [
-                    userConfig.rules[rule][0],
-                    userConfig.rules[rule][1],
-                ];
+                mergedRules[rule] = [...userConfig.rules[rule]];
             }
         });
         const mergedConfig = merge({}, this.getDefaultConfig(), userConfig);

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -19,6 +19,8 @@ module.exports = class Indentation extends Rule {
         lintAfterFix: false,
     };
 
+    static defaultIndentation = 2;
+
     // Rule entry point
     static run(ast, config) {
         return new Indentation(ast, config).execute();
@@ -28,6 +30,10 @@ module.exports = class Indentation extends Rule {
 
     constructor(ast, config) {
         super(ast, config);
+
+        if (!this._config.option.length) {
+            this._config.option.push(Indentation.defaultIndentation);
+        }
     }
 
     execute() {

--- a/tests/lib/gherlint/GherlintConfig.test.js
+++ b/tests/lib/gherlint/GherlintConfig.test.js
@@ -337,7 +337,7 @@ describe("class: GherlintConfig", () => {
                 [
                     "rules config",
                     { rules: { indentation: ["error"] } },
-                    getUpdatedConfig("rules", { indentation: ["error", 2] }),
+                    getUpdatedConfig("rules", { indentation: ["error"] }),
                 ],
             ])("should merge config: %s", (_, userConfig, expectedConfig) => {
                 const config = new GherlintConfig({});

--- a/tests/lib/linter/Linter.test.js
+++ b/tests/lib/linter/Linter.test.js
@@ -133,7 +133,7 @@ describe("class: Linter", () => {
         it("should run all rules", () => {
             const spyGetRuleConfig = jest
                 .spyOn(Linter.prototype, "getRuleConfig")
-                .mockReturnValue({});
+                .mockReturnValue({ type: "error", option: [] });
 
             const linter = new Linter(config);
             const problems = linter.runRules("");


### PR DESCRIPTION
## Description
Set default indentation value when not provided from the config

## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/97


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Documentation updated
