### PR TITLE
fix: resolve path for `.gherlintrc.js` config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Installation on node version higher than 12 gives warning (https://github.com/gherlint/gherlint/pull/72)
 -   Rules that has `off` type also get reported (https://github.com/gherlint/gherlint/pull/96)
 -   NaN when indentation value is not provided (https://github.com/gherlint/gherlint/pull/98)
+-   `.gherlintrc.js` doesn't work from subfolder (https://github.com/gherlint/gherlint/pull/106)

--- a/lib/gherlint/GherlintConfig.js
+++ b/lib/gherlint/GherlintConfig.js
@@ -1,5 +1,6 @@
 const { join, basename, extname } = require("path");
 const fs = require("fs");
+const path = require('path');
 const glob = require("glob");
 const { isEmpty, merge, difference, keys } = require("lodash");
 
@@ -100,7 +101,7 @@ module.exports = class GherlintConfig {
 
     readConfigFromFile(configFile) {
         let config = {};
-
+        
         if (configFile) {
             const extension = extname(basename(configFile));
             try {
@@ -113,7 +114,7 @@ module.exports = class GherlintConfig {
                 ) {
                     config = JSON.parse(Fs.readFile(configFile));
                 } else if (extension === GherlintConfig.CONFIG_EXTENSION.js) {
-                    config = require(configFile);
+                    config = require(path.resolve(configFile));
                 }
             } catch (err) {
                 log.error(

--- a/lib/gherlint/GherlintConfig.js
+++ b/lib/gherlint/GherlintConfig.js
@@ -1,6 +1,6 @@
 const { join, basename, extname } = require("path");
 const fs = require("fs");
-const path = require('path');
+const path = require("path");
 const glob = require("glob");
 const { isEmpty, merge, difference, keys } = require("lodash");
 
@@ -101,7 +101,7 @@ module.exports = class GherlintConfig {
 
     readConfigFromFile(configFile) {
         let config = {};
-        
+
         if (configFile) {
             const extension = extname(basename(configFile));
             try {


### PR DESCRIPTION
## Description
Added path.resolve(configFile) which resolves a sequence of path segments to an absolute path.

Usage:
```bash
gherlint --config <path-to>/.gherlintrc.js
```


## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/105

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Documentation updated
