### PR TITLE
chore: bump version to 1.1.0.alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
 ## [1.0.0] - 2024-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gherlint/gherlint",
-    "version": "1.0.0",
+    "version": "1.1.0-alpha.1",
     "description": "A pattern checker for Gherkin language.",
     "bin": "./bin/gherlint.js",
     "main": "./lib/index.js",


### PR DESCRIPTION
bump version to 1.1.0-alpha.1