### PR TITLE
feat: add an option to configure counting tags and comments as newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   New option for `newline_before_scenario` rule to allow counting tags and comments as a new line (https://github.com/gherlint/gherlint/pull/114)
+    ```js
+    newline_before_scenario: ["error", 2, true];
+    ```
+-   New lint rule:
+    -   `no_but_in_given_when` - checks that But is not used in Given or When steps (https://github.com/gherlint/gherlint/pull/111)
+        ```js
+        no_but_in_given_when: ["warn"];
+        ```
+
 ### Fixed
 
 ## [1.0.0] - 2024-05-13

--- a/lib/gherlint/GherlintConfig.js
+++ b/lib/gherlint/GherlintConfig.js
@@ -243,28 +243,15 @@ module.exports = class GherlintConfig {
                     );
                 }
             } else if (rules[rule] instanceof Array) {
-                if (rules[rule].length > 2) {
+                if (!ruleOptions.includes(rules[rule][0])) {
                     log.error(
                         `[${basename(
                             this.configFilePath
-                        )}] Invalid rule value (expected 2 elements, but got ${
-                            rules[rule].length
-                        })`,
-                        `[RULE] ${rule}: ${rules[rule].join(", ")}`
+                        )}] Invalid rule value!`,
+                        `[RULE] ${rule}: ${
+                            rules[rule][0]
+                        }\n  Expected one of these: ${ruleOptions.join(", ")}`
                     );
-                } else {
-                    if (!ruleOptions.includes(rules[rule][0])) {
-                        log.error(
-                            `[${basename(
-                                this.configFilePath
-                            )}] Invalid rule value!`,
-                            `[RULE] ${rule}: ${
-                                rules[rule][0]
-                            }\n  Expected one of these: ${ruleOptions.join(
-                                ", "
-                            )}`
-                        );
-                    }
                 }
             } else {
                 log.error(

--- a/lib/rules/newline_before_scenario.js
+++ b/lib/rules/newline_before_scenario.js
@@ -15,6 +15,8 @@ module.exports = class NewlineBeforeScenario extends Rule {
     };
 
     static defaultNewline = 1;
+    // count tag and comment lines as newlines
+    static countTagCommentLine = false;
 
     #comments = [];
     #lastLine = 0;
@@ -24,6 +26,11 @@ module.exports = class NewlineBeforeScenario extends Rule {
 
         if (!this._config.option.length) {
             this._config.option.push(NewlineBeforeScenario.defaultNewline);
+            this._config.option.push(NewlineBeforeScenario.countTagCommentLine);
+        } else if (this._config.option.length === 1) {
+            this._config.option.push(NewlineBeforeScenario.countTagCommentLine);
+        } else if (typeof this._config.option[1] !== "boolean") {
+            this._config.option.push(NewlineBeforeScenario.countTagCommentLine);
         }
     }
 
@@ -48,27 +55,43 @@ module.exports = class NewlineBeforeScenario extends Rule {
             // NOTE: the order of code execution matters
             if (keyword === "scenario") {
                 // -1 to exclude the last one
-                let lineDiff =
+                let newLines =
                     astObject[keyword].location.line - this.#lastLine - 1;
 
                 const commentsCount = this.getCommentCountBetweenLines(
                     this.#lastLine,
                     astObject[keyword].location.line
                 );
-                lineDiff =
-                    lineDiff -
-                    this.getTagLine(astObject[keyword].tags) -
-                    commentsCount;
+                const tagLines = this.getTagLine(astObject[keyword].tags);
+                newLines = newLines - tagLines - commentsCount;
+                let expectedNewline = this._config.option[0];
 
-                if (lineDiff !== this._config.option[0]) {
+                if (this._config.option[1] && (tagLines || commentsCount)) {
+                    expectedNewline = NewlineBeforeScenario.defaultNewline;
+                }
+
+                // at least 1 newline before Scenario
+                if (newLines === 0) {
                     this.storeLintProblem({
                         ...NewlineBeforeScenario.meta,
                         type: this._config.type,
-                        message: format(
-                            NewlineBeforeScenario.meta.message,
-                            this._config.option[0],
-                            lineDiff
-                        ),
+                        message: "Expected at least 1 newline before Scenario",
+                        location: astObject[keyword].location,
+                    });
+                } else if (newLines !== expectedNewline) {
+                    let message = format(
+                        NewlineBeforeScenario.meta.message,
+                        expectedNewline,
+                        newLines
+                    );
+                    if (this._config.option[1]) {
+                        message += " (including tags and comments)";
+                    }
+
+                    this.storeLintProblem({
+                        ...NewlineBeforeScenario.meta,
+                        type: this._config.type,
+                        message,
                         location: astObject[keyword].location,
                     });
                 }

--- a/tests/__fixtures__/Rules/newline_before_scenario/fixture.js
+++ b/tests/__fixtures__/Rules/newline_before_scenario/fixture.js
@@ -2,12 +2,14 @@ const { format } = require("util");
 const generator = require("../../../helpers/problemGenerator");
 const NewlineBeforeScenario = require("../../../../lib/rules/newline_before_scenario");
 
-function generateProblem(location, actual, expected = 1) {
-    return generator(
-        NewlineBeforeScenario,
-        location,
-        format(NewlineBeforeScenario.meta.message, expected, actual)
-    );
+function generateProblem(location, actual, expected = 1, message = "") {
+    if (!message) {
+        message = format(NewlineBeforeScenario.meta.message, expected, actual);
+    }
+    if (actual === 0) {
+        message = "Expected at least 1 newline before Scenario";
+    }
+    return generator(NewlineBeforeScenario, location, message);
 }
 
 function getValidTestData() {

--- a/tests/lib/gherlint/GherlintConfig.test.js
+++ b/tests/lib/gherlint/GherlintConfig.test.js
@@ -591,15 +591,6 @@ describe("class: GherlintConfig", () => {
                         "[RULE] indentation: extra\n  Expected one of these: off, warn, error",
                     ],
                 ],
-                [
-                    {
-                        indentation: ["warn", 2, "extra"],
-                    },
-                    [
-                        "[.gherlintrc] Invalid rule value (expected 2 elements, but got 3)",
-                        "[RULE] indentation: warn, 2, extra",
-                    ],
-                ],
             ])("should complain if rules are invalid", (rules, errMessage) => {
                 const spyOnExit = jest
                     .spyOn(process, "exit")

--- a/tests/lib/rules/newline_before_scenario.test.js
+++ b/tests/lib/rules/newline_before_scenario.test.js
@@ -53,19 +53,62 @@ describe("newline_before_scenario", () => {
         });
     });
 
-    describe("custom newline requirement", () => {
+    describe("custom option: change newline requirement", () => {
         const customConfig = {
             type: "error",
             option: [2],
         };
         it.each([
             [
-                "less newlines",
+                "valid number of newlines",
+                "Feature: a feature\n\n\n  Scenario: a scenario",
+                [],
+            ],
+            [
+                "valid number of newlines with a tag",
+                "Feature: a feature\n\n\n  @tag\n  Scenario: a scenario",
+                [],
+            ],
+            [
+                "no newline",
                 "Feature: a feature\n  Scenario: a scenario",
                 [
                     generateProblem(
                         { line: 2, column: 3 },
                         0,
+                        customConfig.option[0]
+                    ),
+                ],
+            ],
+            [
+                "no newline with a tag",
+                "Feature: a feature\n  @tag\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 3, column: 3 },
+                        0,
+                        customConfig.option[0]
+                    ),
+                ],
+            ],
+            [
+                "less newlines with a tag",
+                "Feature: a feature\n\n  @tag\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 4, column: 3 },
+                        1,
+                        customConfig.option[0]
+                    ),
+                ],
+            ],
+            [
+                "less newlines",
+                "Feature: a feature\n\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 3, column: 3 },
+                        1,
                         customConfig.option[0]
                     ),
                 ],
@@ -78,6 +121,66 @@ describe("newline_before_scenario", () => {
                         { line: 5, column: 3 },
                         3,
                         customConfig.option[0]
+                    ),
+                ],
+            ],
+            [
+                "more newlines with a tag",
+                "Feature: a feature\n\n\n\n  @tag\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 6, column: 3 },
+                        3,
+                        customConfig.option[0]
+                    ),
+                ],
+            ],
+        ])("%s", (_, text, expectedProblems) => {
+            const ast = parser.parse(text);
+            const problems = NewlineBeforeScenario.run(ast, customConfig);
+            expect(problems.length).toEqual(expectedProblems.length);
+            problems.forEach((problem, index) => {
+                expect(problem.location).toEqual(
+                    expectedProblems[index].location
+                );
+                expect(problem.message).toEqual(
+                    expectedProblems[index].message
+                );
+            });
+        });
+    });
+
+    describe("custom option: count tag and comment as newline", () => {
+        const customConfig = {
+            type: "error",
+            option: [2, true],
+        };
+        it.each([
+            [
+                "valid number of new lines",
+                "Feature: a feature\n\n  @tag\n  Scenario: a scenario",
+                [],
+            ],
+            [
+                "no newline",
+                "Feature: a feature\n  @tag\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 3, column: 3 },
+                        0,
+                        customConfig.option[0]
+                    ),
+                ],
+            ],
+            [
+                "more newlines",
+                "Feature: a feature\n\n\n\n  @tag\n  Scenario: a scenario",
+                [
+                    generateProblem(
+                        { line: 6, column: 3 },
+                        3,
+                        customConfig.option[0],
+                        "Expected 1 newline(s) before Scenario but found 3 (including tags and comments)"
                     ),
                 ],
             ],


### PR DESCRIPTION
## Description
Added third option to rule `newline_before_scenario` which is used to configure whether to count tags and comments as new lines or not.

Usage:
```js
{
  rules: {
    newline_before_scenario: ["error", 2, true]
  }
}
```

Default: `false` (to not break the current config behavior)

## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/113

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Documentation updated
