### PR TITLE
feat: allow more than one But in Then section of a Scenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         no_but_in_given_when: ["warn"];
         ```
 
+### Changed
+
+-   Allow more than one inconsecutive But in Then section of a Scenario (https://github.com/gherlint/gherlint/pull/115)
+
 ### Fixed
 
 ## [1.0.0] - 2024-05-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Allow more than one inconsecutive But in Then section of a Scenario (https://github.com/gherlint/gherlint/pull/115)
+-   Allow more than one nonconsecutive But in Then section of a Scenario (https://github.com/gherlint/gherlint/pull/115)
 
 ### Fixed
 

--- a/lib/rules/no_repetitive_step_keyword.js
+++ b/lib/rules/no_repetitive_step_keyword.js
@@ -18,6 +18,9 @@ module.exports = class NoRepetitiveStepKeyword extends Rule {
         lintAfterFix: false,
     };
 
+    static repeatableKeywords = ["And", "*"];
+    static inconsecutiveRepeatableKeywords = ["But"];
+
     // Rule entry point
     static run(ast, config) {
         return new NoRepetitiveStepKeyword(ast, config).execute();
@@ -81,7 +84,16 @@ module.exports = class NoRepetitiveStepKeyword extends Rule {
                 this.storeLintProblem(problem);
             }
             // 'And' and '*' can be used repeatedly
-            if (keyword === "And" || keyword === "*") return;
+            if (NoRepetitiveStepKeyword.repeatableKeywords.includes(keyword)) {
+                if (
+                    NoRepetitiveStepKeyword.inconsecutiveRepeatableKeywords.includes(
+                        currentStep
+                    )
+                ) {
+                    currentStep = null;
+                }
+                return;
+            }
             currentStep = keyword;
         });
     }

--- a/lib/rules/no_repetitive_step_keyword.js
+++ b/lib/rules/no_repetitive_step_keyword.js
@@ -19,7 +19,7 @@ module.exports = class NoRepetitiveStepKeyword extends Rule {
     };
 
     static repeatableKeywords = ["And", "*"];
-    static inconsecutiveRepeatableKeywords = ["But"];
+    static nonconsecutiveRepeatableKeywords = ["But"];
 
     // Rule entry point
     static run(ast, config) {
@@ -86,7 +86,7 @@ module.exports = class NoRepetitiveStepKeyword extends Rule {
             // 'And' and '*' can be used repeatedly
             if (NoRepetitiveStepKeyword.repeatableKeywords.includes(keyword)) {
                 if (
-                    NoRepetitiveStepKeyword.inconsecutiveRepeatableKeywords.includes(
+                    NoRepetitiveStepKeyword.nonconsecutiveRepeatableKeywords.includes(
                         currentStep
                     )
                 ) {

--- a/tests/__fixtures__/Rules/no_repetitive_step_keyword/fixture.js
+++ b/tests/__fixtures__/Rules/no_repetitive_step_keyword/fixture.js
@@ -77,7 +77,7 @@ function getValidTestData() {
             [],
         ],
         [
-            "Multiple inconsecutive But",
+            "Multiple nonconsecutive But",
             `Feature: a feature file
   Background: a background
     When a step
@@ -225,7 +225,7 @@ function getInvalidTestDataWithFix() {
     And a step`,
         ],
         [
-            "without Rule: consecutive repetative But",
+            "without Rule: consecutive repetitive But",
             `Feature: a feature file
 Scenario: a scenario
   Then a step

--- a/tests/__fixtures__/Rules/no_repetitive_step_keyword/fixture.js
+++ b/tests/__fixtures__/Rules/no_repetitive_step_keyword/fixture.js
@@ -76,6 +76,19 @@ function getValidTestData() {
     * a step`,
             [],
         ],
+        [
+            "Multiple inconsecutive But",
+            `Feature: a feature file
+  Background: a background
+    When a step
+    Then a step
+    But a step
+    And a step
+    But a step
+    And a step
+    But a step`,
+            [],
+        ],
     ];
 }
 function getInvalidTestData() {
@@ -108,6 +121,8 @@ function getInvalidTestData() {
     Then a step
     But a step
     But a step
+    And a step
+    But a step
   Scenario Outline: a scenario outline
     When a step
     When a step
@@ -120,8 +135,8 @@ function getInvalidTestData() {
                 generateProblem({ line: 4, column: 5 }, "Given"),
                 generateProblem({ line: 8, column: 5 }, "Then"),
                 generateProblem({ line: 10, column: 5 }, "But"),
-                generateProblem({ line: 13, column: 5 }, "When"),
-                generateProblem({ line: 14, column: 5 }, "When"),
+                generateProblem({ line: 15, column: 5 }, "When"),
+                generateProblem({ line: 16, column: 5 }, "When"),
             ],
         ],
     ];
@@ -208,6 +223,24 @@ function getInvalidTestDataWithFix() {
   Scenario Outline: a scenario outline
     Given a step
     And a step`,
+        ],
+        [
+            "without Rule: consecutive repetative But",
+            `Feature: a feature file
+Scenario: a scenario
+  Then a step
+  But a step
+  But a step
+  And a step
+  But a step`,
+            generateProblem({ line: 5 }, "But"),
+            `Feature: a feature file
+Scenario: a scenario
+  Then a step
+  But a step
+  And a step
+  And a step
+  But a step`,
         ],
     ];
 }


### PR DESCRIPTION
## Description
Allow more than one But in Then section of Scenario


```feature
Scenario: a scenario
  When a step
  Then a step
  But a step
  And a step
  But a step ✔️

Scenario: a scenario
  When a step
  Then a step
  But a step
  And a step
  But a step ✔️
  And a step
  And a step
  But a step ✔️
```

```feature
Scenario: a scenario
  When a step
  Then a step
  But a step
  But a step ❌
  And a step

Scenario: a scenario
  When a step
  Then a step
  But a step
  And a step
  But a step
  But a step ❌
```
## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/109

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
