### PR TITLE
fix: lines with only whitespace are reported in DocStrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Fix whitespaces reported in DocStrings (https://github.com/gherlint/gherlint/pull/116)
+
 ## [1.0.0] - 2024-05-13
 
 ### Added

--- a/lib/rules/no_trailing_whitespace.js
+++ b/lib/rules/no_trailing_whitespace.js
@@ -14,8 +14,24 @@ module.exports = class NoTrailingWhitespace extends Rule {
 
         const problems = [];
         let lineIndex = 0;
+        let docString = false;
+        const docStringRegex = /[ \t]*"""/;
+
         for (const line of ast.text.split("\n")) {
             lineIndex++;
+
+            // eslint-disable-next-line quotes
+            if (docString && docStringRegex.test(line)) {
+                docString = false;
+                continue;
+                // eslint-disable-next-line quotes
+            } else if (docStringRegex.test(line)) {
+                docString = true;
+                continue;
+            }
+
+            if (docString) continue;
+
             const match = line.match(/\s+$/);
             if (match !== null) {
                 const location = { line: lineIndex, column: match.index + 1 };

--- a/tests/__fixtures__/Rules/no_trailing_whitespace/fixture.js
+++ b/tests/__fixtures__/Rules/no_trailing_whitespace/fixture.js
@@ -26,6 +26,23 @@ function getValidTestData() {
 `,
             [],
         ],
+        [
+            "white spaces in docstring should be ignored",
+            `Feature: a feature file
+  Scenario: a scenario
+    When a step
+      """
+      lorem
+        start with spaces
+      some with spaces at the end      
+
+
+        end with spaces
+        
+      """
+`,
+            [],
+        ],
     ];
 }
 function getInvalidTestData() {


### PR DESCRIPTION
## Description
Do not report whitespaces in the docstring

## Related Issue
- Fixes https://github.com/gherlint/gherlint/issues/110

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
