### PR TITLE
fix: trim comments before checking them

### DIFF
--- a/lib/rules/grammar_check.js
+++ b/lib/rules/grammar_check.js
@@ -65,11 +65,13 @@ module.exports = class GrammarCheck extends Rule {
         }
 
         for (const comment of this._ast.comments) {
-            harperLints = await linter.lint(comment.text, lintOptions);
+            const trimmedLine = trimStart(comment.text);
+            const columnOffset = comment.text.length - trimmedLine.length + 1;
+            harperLints = await linter.lint(trimmedLine, lintOptions);
             problems = [
                 ...problems,
                 ...this.compileLintProblems(
-                    harperLints, comment.location.line, comment.location.column
+                    harperLints, comment.location.line, columnOffset
                 )
             ];
         }

--- a/tests/__fixtures__/Rules/grammar_check/fixture.js
+++ b/tests/__fixtures__/Rules/grammar_check/fixture.js
@@ -59,7 +59,8 @@ As a developer,
 I want my feature files to be grammatically correct
 So that it looks like I've paid attention in high school
 
-# but in these commen there are mustakes`,
+    # but in these commen there are mustakes
+    # also if there are multii line`,
             [
                 generateProblem(
                     {line: 1, column: "55-59"},
@@ -67,14 +68,19 @@ So that it looks like I've paid attention in high school
                     " Suggestions: Replace with 'file' OR Replace with 'flue' OR Replace with 'fuel'"
                 ),
                 generateProblem(
-                    {line: 7, column: "16-22"},
+                    {line: 7, column: "20-26"},
                     "Did you mean to spell `commen` this way?" +
                     " Suggestions: Replace with 'comment' OR Replace with 'common' OR Replace with 'commend'"
                 ),
                 generateProblem(
-                    {line: 7, column: "33-41"},
+                    {line: 7, column: "37-45"},
                     "Did you mean to spell `mustakes` this way?" +
                     " Suggestions: Replace with 'mistakes' OR Replace with 'mistake's' OR Replace with 'mistake'"
+                ),
+                generateProblem(
+                    {line: 8, column: "25-31"},
+                    "Did you mean to spell `multii` this way?" +
+                    " Suggestions: Replace with 'multi' OR Replace with 'mufti' OR Replace with 'muftis'"
                 ),
             ],
         ],


### PR DESCRIPTION
## Description
Without this fix, we get "French spaces" errors, if there are spaces before the comment


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
