### PR TITLE
feat: string replacement before grammar check

### DIFF
--- a/lib/rules/grammar_check.js
+++ b/lib/rules/grammar_check.js
@@ -52,40 +52,43 @@ module.exports = class GrammarCheck extends Rule {
         }
 
         const lintOptions = {language: "plaintext"};
-
-        let harperLints = await linter.lint(this._ast.feature.keyword + ": " + this._ast.feature.name, lintOptions);
-        let problems = this.compileLintProblems(
-            harperLints, this._ast.feature.location.line, 1
+        let linesToCheck = [];
+        linesToCheck.push(
+            {
+                text: this._ast.feature.keyword + ": " + this._ast.feature.name,
+                lineOffset: this._ast.feature.location.line,
+                columnOffset: 1,
+            }
         );
 
         let lineNumber = 1;
         for (const line of this._ast.feature.description.split("\n")) {
             const trimmedLine = trimStart(line);
             const columnOffset = line.length - trimmedLine.length + 1;
-            harperLints = await linter.lint(trimmedLine, lintOptions);
-            problems = [
-                ...problems,
-                ...this.compileLintProblems(
-                    harperLints, this._ast.feature.location.line + lineNumber, columnOffset
-                )
-            ];
+            linesToCheck.push(
+                {
+                    text: trimmedLine,
+                    lineOffset: this._ast.feature.location.line + lineNumber,
+                    columnOffset: columnOffset,
+                }
+            );
             lineNumber++;
         }
 
         for (const comment of this._ast.comments) {
             const trimmedLine = trimStart(comment.text);
             const columnOffset = comment.text.length - trimmedLine.length + 1;
-            harperLints = await linter.lint(trimmedLine, lintOptions);
-            problems = [
-                ...problems,
-                ...this.compileLintProblems(
-                    harperLints, comment.location.line, columnOffset
-                )
-            ];
+            linesToCheck.push(
+                {
+                    text: trimmedLine,
+                    lineOffset: comment.location.line,
+                    columnOffset: columnOffset,
+                }
+            );
         }
 
         for (const child of this._ast.feature.children) {
-            let textToCheck="";
+            let textToCheck = "";
             let lineOffset = 0;
             let columnOffset = 0;
             if (child.background && child.background.name) {
@@ -103,13 +106,13 @@ module.exports = class GrammarCheck extends Rule {
                 lineOffset = child.scenario.location.line;
                 columnOffset = child.scenario.location.column;
             }
-            harperLints = await linter.lint(textToCheck, lintOptions);
-            problems = [
-                ...problems,
-                ...this.compileLintProblems(
-                    harperLints, lineOffset, columnOffset
-                )
-            ];
+            linesToCheck.push(
+                {
+                    text: textToCheck,
+                    lineOffset: lineOffset,
+                    columnOffset: columnOffset,
+                }
+            );
             let steps = [];
             if (child.scenario && child.scenario.steps) {
                 steps = child.scenario.steps;
@@ -117,36 +120,36 @@ module.exports = class GrammarCheck extends Rule {
                 steps = child.background.steps;
             }
             for (const step of steps) {
-                harperLints = await linter.lint(step.keyword + step.text, lintOptions);
-                problems = [
-                    ...problems,
-                    ...this.compileLintProblems(
-                        harperLints, step.location.line, step.location.column
-                    )
-                ];
+                linesToCheck.push(
+                    {
+                        text: step.keyword + step.text,
+                        lineOffset: step.location.line,
+                        columnOffset: step.location.column,
+                    }
+                );
                 if (step.docString) {
                     let lineNumber = 1;
                     for (const line of step.docString.content.split("\n")) {
-                        harperLints = await linter.lint(line, lintOptions);
-                        problems = [
-                            ...problems,
-                            ...this.compileLintProblems(
-                                harperLints, step.docString.location.line + lineNumber, step.docString.location.column
-                            )
-                        ];
+                        linesToCheck.push(
+                            {
+                                text: line,
+                                lineOffset: step.docString.location.line + lineNumber,
+                                columnOffset: step.docString.location.column,
+                            }
+                        );
                         lineNumber++;
                     }
                 }
                 if (step.dataTable && step.dataTable.rows.length > 0) {
                     for (const row of step.dataTable.rows) {
                         for (const cell of row.cells) {
-                            harperLints = await linter.lint(cell.value, lintOptions);
-                            problems = [
-                                ...problems,
-                                ...this.compileLintProblems(
-                                    harperLints, cell.location.line, cell.location.column
-                                )
-                            ];
+                            linesToCheck.push(
+                                {
+                                    text: cell.value,
+                                    lineOffset: cell.location.line,
+                                    columnOffset: cell.location.column,
+                                }
+                            );
                         }
                     }
                 }
@@ -158,21 +161,34 @@ module.exports = class GrammarCheck extends Rule {
                         cells = [...cells, ...row.cells];
                     }
                     for (const cell of cells) {
-                        harperLints = await linter.lint(cell.value, lintOptions);
-                        problems = [
-                            ...problems,
-                            ...this.compileLintProblems(
-                                harperLints, cell.location.line, cell.location.column
-                            )
-                        ];
+                        linesToCheck.push(
+                            {
+                                text: cell.value,
+                                lineOffset: cell.location.line,
+                                columnOffset: cell.location.column,
+                            }
+                        );
                     }
                 }
             }
 
         }
 
-        for (const problem of problems) {
-            this.storeLintProblem(problem);
+        for (const line of linesToCheck) {
+            if (this._config.option && this._config.option.length > 3) {
+                for (const replacement of this._config.option[3]) {
+                    if (replacement[0] !== undefined && replacement[1] !== undefined ) {
+                        line.text = line.text.replaceAll(replacement[0], replacement[1]);
+                    }
+                }
+            }
+            const harperLints = await linter.lint(line.text, lintOptions);
+            const problems = this.compileLintProblems(
+                harperLints, line.lineOffset, line.columnOffset
+            );
+            for (const problem of problems) {
+                this.storeLintProblem(problem);
+            }
         }
 
         return this.getProblems();

--- a/tests/lib/rules/grammar_check.test.js
+++ b/tests/lib/rules/grammar_check.test.js
@@ -58,6 +58,30 @@ This tool can be piggy bag`
             expect(problems.length).toEqual(1);
             expect(problems[0].message).toBe("Did you mean `piggyback`? Suggestions: Replace with 'piggyback'");
         });
+        test("replace strings", async () => {
+            config = {
+                type: "error",
+                option: [
+                    "",
+                    [],
+                    {},
+                    [
+                        ["\\n", " "],
+                        ["~", ""],
+                    ]
+                ],
+            };
+            const linter = new Linter();
+            const ast = linter.parseAst(
+                `Feature: steps can have special characters
+  Scenario: step with line break
+    When a step contains "a\\nline break"
+    And a step contains spec~ial characters`
+            );
+            const problems = await GrammarCheck.run(ast, config);
+
+            expect(problems.length).toEqual(0);
+        });
     });
 
     describe("invalid ast", () => {


### PR DESCRIPTION
## Description
This introduces an other option for the grammar check. It allows the user to replace special characters before doing the grammar check.

## Motivation and Context
in Feature files we might have special characters and that confuses harper. 
E.g. in a feature that says:
`Then the displayed text should be "My string\nhas a line-break"` harper would try to lint `nhas` as one word.

## How Has This Been Tested?
- unit-test
- real life feature file

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
