### PR TITLE
feat: new rule then_should_have_should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   New lint rule:
+    - `then_should_have_should` - checks that every Then step contains a 'should' (https://github.com/gherlint/gherlint/pull/145)
 -   Use [harper](https://github.com/Automattic/harper/) to check the grammar of the feature files
 
 ### Changed

--- a/lib/config/gherlintrc.js
+++ b/lib/config/gherlintrc.js
@@ -30,5 +30,6 @@ module.exports = {
         no_but_in_given_when: "warn",
         require_when_and_then_step: "warn",
         grammar_check: "warn",
+        then_should_have_should: "error",
     },
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -14,5 +14,6 @@ module.exports = {
         no_but_in_given_when: require("./no_but_in_given_when"),
         require_when_and_then_step: require("./require_when_and_then_step"),
         grammar_check: require("./grammar_check"),
+        then_should_have_should: require("./then_should_have_should")
     },
 };

--- a/lib/rules/then_should_have_should.js
+++ b/lib/rules/then_should_have_should.js
@@ -1,0 +1,56 @@
+const Rule = require("./Rule");
+const {isEmpty: _isEmpty} = require("lodash");
+
+module.exports = class ThenShouldHaveShould extends Rule {
+    static meta = {
+        ruleId: "then_should_have_should",
+        message: "Every Then step should contain the world 'should'",
+        type: "error", // (warn | error | off)
+        hasFix: false, // (true | false) - if the rule has a fixer or not
+    };
+
+    constructor(ast, config) {
+        super(ast, config);
+    }
+
+    static async run(ast, config) {
+        return await new ThenShouldHaveShould(ast, config).execute();
+    }
+
+    async execute() {
+        if (_isEmpty(this._ast?.feature)) {
+            return [];
+        }
+
+        for (const child of this._ast.feature.children) {
+            let steps = [];
+            if (child.scenario && child.scenario.steps) {
+                steps = child.scenario.steps;
+            } else if (child.background && child.background.steps) {
+                steps = child.background.steps;
+            }
+            let inThen = false;
+            for (const step of steps) {
+                if (step.keywordType === "Outcome"){
+                    inThen = true;
+                } else if (step.keywordType !== "Conjunction"){
+                    inThen = false;
+                }
+
+                if (inThen && step.text.search(/\sshould\s/) === -1) {
+                    this.storeLintProblem({
+                        ...ThenShouldHaveShould.meta,
+                        type: this._config.type,
+                        message: ThenShouldHaveShould.meta.message,
+                        location: {
+                            line: step.location.line,
+                            column: step.location.column
+                        },
+                    });
+                }
+            }
+        }
+
+        return this.getProblems();
+    }
+};

--- a/tests/__fixtures__/Rules/then_should_have_should/fixture.js
+++ b/tests/__fixtures__/Rules/then_should_have_should/fixture.js
@@ -1,0 +1,101 @@
+const generator = require("../../../helpers/problemGenerator");
+const ThenShouldHaveShould = require("../../../../lib/rules/then_should_have_should");
+
+function generateProblem(location, message) {
+    return generator(ThenShouldHaveShould, location, message, {
+        applyFix: jest.fn(),
+    });
+}
+
+function getTestData() {
+    return [
+        [
+            "no then step",
+            `Feature: ThenShouldHaveShould
+  Scenario: without a Then step
+    Given a feature does not have a Then step
+    When the user runs the 'ThenShouldHaveShould' rule`,
+            [
+            ],
+        ],
+        [
+            "correct then step",
+            `Feature: ThenShouldHaveShould
+  Scenario: with a Then step
+    Given a feature does have a Then step
+    When the user runs the 'ThenShouldHaveShould' rule
+    Then every "Then" step should contain the magic word`,
+            [
+            ],
+        ],
+        [
+            "then step without should",
+            `Feature: ThenShouldHaveShould
+  Scenario: with a Then step, but without a should
+    Given a feature does have a Then step
+    And the Then step does not contain a "should"
+    When the user runs the 'ThenShouldHaveShould' rule
+    Then an error will be thrown`,
+            [
+                generateProblem(
+                    {line: 6, column: 5},
+                    "Every Then step should contain the world 'should'"
+                ),
+            ],
+        ],
+        [
+            "then step has a should, but following And does not",
+            `Feature: ThenShouldHaveShould
+  Scenario: with a Then step, but without a should
+    Given a feature does have a Then step
+    And the Then step does contain a "should"
+    But the following And does not
+    When the user runs the 'ThenShouldHaveShould' rule
+    Then an error should be thrown
+    And an error will be thrown`,
+            [
+                generateProblem(
+                    {line: 8, column: 5},
+                    "Every Then step should contain the world 'should'"
+                ),
+            ],
+        ],
+        [
+            "then step has a should, but following But does not",
+            `Feature: ThenShouldHaveShould
+  Scenario: with a Then step, but without a should
+    Given a feature does have a Then step
+    And the Then step does contain a "should"
+    But the following But does not
+    When the user runs the 'ThenShouldHaveShould' rule
+    Then an error should be thrown
+    But an error will be thrown`,
+            [
+                generateProblem(
+                    {line: 8, column: 5},
+                    "Every Then step should contain the world 'should'"
+                ),
+            ],
+        ],
+        [
+            "then step without should in background",
+            `Feature: ThenShouldHaveShould
+  Background: with a Then step, but without a should
+    Given a feature does have a Then step
+    And the Then step does not contain a "should"
+    When the user runs the 'ThenShouldHaveShould' rule
+    Then an error will be thrown`,
+            [
+                generateProblem(
+                    {line: 6, column: 5},
+                    "Every Then step should contain the world 'should'"
+                ),
+            ],
+        ],
+    ];
+}
+
+module.exports = {
+    generateProblem,
+    getTestData,
+};

--- a/tests/lib/rules/then_should_have_should.test.js
+++ b/tests/lib/rules/then_should_have_should.test.js
@@ -1,0 +1,42 @@
+const {
+    getTestData,
+} = require("../../__fixtures__/Rules/then_should_have_should/fixture");
+const ThenShouldHavaShould = require("../../../lib/rules/then_should_have_should");
+const {Linter} = require("../../../lib/linter");
+
+let config = {
+    type: "error",
+};
+
+describe("Then should have should", () => {
+
+    describe("invalid ast", () => {
+        it.each([[undefined], [null], [""], [{}]])(
+            "'%s': should return undefined",
+            async (ast) => {
+                const problems = await ThenShouldHavaShould.run(ast, config);
+                expect(problems).toEqual([]);
+            }
+        );
+    });
+
+    describe("then should have a 'should'", () => {
+        const testData = getTestData();
+
+        it.each(testData)("%s", async (_, text, expectedProblems) => {
+            const linter = new Linter();
+            const ast = linter.parseAst(text);
+            const problems = await ThenShouldHavaShould.run(ast, config);
+
+            expect(problems.length).toEqual(expectedProblems.length);
+            problems.forEach((problem, index) => {
+                expect(problem.location).toEqual(
+                    expectedProblems[index].location
+                );
+                expect(problem.message).toEqual(
+                    expectedProblems[index].message
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
a new rule that checks that every Then step contains a 'should'

## How Has This Been Tested?
- unit tests

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Documentation updated
