### PR TITLE
feat: new rule - words_to_avoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   New lint rule:
     - `then_should_have_should` - checks that every Then step contains a 'should' (https://github.com/gherlint/gherlint/pull/145)
 -   Use [harper](https://github.com/Automattic/harper/) to check the grammar of the feature files
+-   New lint rule that checks for unwanted words in steps
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ e.g.
   ]
 ```
 
+**words_to_avoid**
+1. level `string`
+2. strings to avoid `string[][]` where the inner array has two items, first being the string to avaoid and the second optionally a custom error message.
+
+e.g.
+```
+"words_to_avoid": [
+  "error",
+  [
+     ["click"],
+     ["clicks"],
+     ["clicked"],
+     ["see", "Describe the behavior of the app, not what the user sees."],
+     ["sees", "Describe the behavior of the app, not what the user sees."],
+     ["seen", "Describe the behavior of the app, not what the user sees."]
+  ]
+]
+```
+
 ## Code of Conduct
 
 GherLint adheres to this [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/lib/config/gherlintrc.js
+++ b/lib/config/gherlintrc.js
@@ -31,5 +31,6 @@ module.exports = {
         require_when_and_then_step: "warn",
         grammar_check: "warn",
         then_should_have_should: "error",
+        words_to_avoid: "error",
     },
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -14,6 +14,7 @@ module.exports = {
         no_but_in_given_when: require("./no_but_in_given_when"),
         require_when_and_then_step: require("./require_when_and_then_step"),
         grammar_check: require("./grammar_check"),
-        then_should_have_should: require("./then_should_have_should")
+        then_should_have_should: require("./then_should_have_should"),
+        words_to_avoid: require("./words_to_avoid")
     },
 };

--- a/lib/rules/words_to_avoid.js
+++ b/lib/rules/words_to_avoid.js
@@ -1,0 +1,75 @@
+const Rule = require("./Rule");
+const {isEmpty: _isEmpty, isArray} = require("lodash");
+const {format} = require("node:util");
+
+module.exports = class WordsToAvoid extends Rule {
+    static meta = {
+        ruleId: "words_to_avoid",
+        type: "error", // (warn | error | off)
+        message: "Do not use the word '%s'.%s",
+        hasFix: false, // (true | false) - if the rule has a fixer or not
+    };
+
+    constructor(ast, config) {
+        super(ast, config);
+    }
+
+    static run(ast, config) {
+        return new WordsToAvoid(ast, config).execute();
+    }
+
+    execute() {
+        if (_isEmpty(this._ast?.feature)) {
+            return [];
+        }
+
+        let wordsToAvoid = [];
+        if (this._config.option && this._config.option.length > 0 && isArray(this._config.option)) {
+            wordsToAvoid = this._config.option[0];
+        }
+        for (const word of wordsToAvoid) {
+            const string = word[0];
+            let error = "";
+            if (word.length > 1) {
+                error = " " + word[1];
+            }
+            for (const child of this._ast.feature.children) {
+                let steps = [];
+                if (child.scenario && child.scenario.steps) {
+                    steps = child.scenario.steps;
+                } else if (child.background && child.background.steps) {
+                    steps = child.background.steps;
+                }
+                for (const step of steps) {
+                    const searchRegex = new RegExp(`\\b${string}\\b`,"g");
+                    let searchResult;
+
+                    while ((searchResult = searchRegex.exec(step.text)) !== null) {
+                        this.storeLintProblem({
+                            ...WordsToAvoid.meta,
+                            type: this._config.type,
+                            message: format(WordsToAvoid.meta.message, string, error),
+                            location: {
+                                line: step.location.line,
+                                column: step.location.column + step.keyword.length + searchResult.index
+                                // the keyword already contains a space so `step.keyword.length` returns
+                                // e.g. for Given => 6
+                            },
+                        });
+                    }
+
+                }
+            }
+        }
+
+        // do some ordering, because we run first through the words and then lines
+        let problems = this.getProblems();
+        return problems.sort((a, b) => {
+            const lineDiff = a.location.line - b.location.line;
+            if (lineDiff !== 0) {
+                return lineDiff;
+            }
+            return a.location.column - b.location.column;
+        });
+    }
+};

--- a/tests/__fixtures__/Rules/words_to_avoid/fixture.js
+++ b/tests/__fixtures__/Rules/words_to_avoid/fixture.js
@@ -1,0 +1,305 @@
+const generator = require("../../../helpers/problemGenerator");
+const WordsToAvoid = require("../../../../lib/rules/words_to_avoid");
+
+function generateProblem(location, message) {
+    return generator(WordsToAvoid, location, message, {
+        applyFix: jest.fn(),
+    });
+}
+
+function getTestData() {
+    return [
+        [
+            "no step",
+            `Feature: WordsToAvoid
+  Scenario: without any step`,
+            [
+            ],
+        ],
+        [
+            "all steps correct",
+            `Feature: WordsToAvoid
+  Scenario: without any word to avoid
+    Given a feature does have a Then step
+    When the user runs the 'WordsToAvoid' rule
+    And every step is correct
+    Then no error should be shown`,
+            [
+            ],
+        ],
+        [
+            "given step contains a word to avoid",
+            `Feature: WordsToAvoid
+  Scenario: with a Given step that contains one of the bad words
+    Given a given step contains the word sees
+    And that word is to be avoided
+    When the user runs the 'WordsToAvoid' rule
+    Then an error should be thrown`,
+            [
+                generateProblem(
+                    {line: 3, column: 42},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "given step in background contains a word to avoid",
+            `Feature: WordsToAvoid
+  Background: with a Given step that contains one of the bad words
+    Given a given step contains the word sees
+    And that word is to be avoided
+
+  Scenario:
+    When the user runs the 'WordsToAvoid' rule
+    Then an error should be thrown`,
+            [
+                generateProblem(
+                    {line: 3, column: 42},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "when step contains a word to avoid",
+            `Feature: WordsToAvoid
+  Scenario: with a Then step that contains one of the bad words
+    Given a when step contains a bad word
+    When the linter sees the word
+    Then an error should be thrown`,
+            [
+                generateProblem(
+                    {line: 4, column: 21},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "and step contains a word to avoid",
+            `Feature: WordsToAvoid
+  Scenario: with a Then step that contains one of the bad words
+    Given a And step contains a bad word
+    When the user runs the 'WordsToAvoid' rule
+    And the linter sees the word
+    Then an error should be thrown`,
+            [
+                generateProblem(
+                    {line: 5, column: 20},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "then step contains a word to avoid",
+            `Feature: WordsToAvoid
+  Scenario: with a Then step that contains one of the bad words
+    Given a feature does have a Then step
+    And the Then step does contain a bad words
+    When the user runs the 'WordsToAvoid' rule
+    Then the user sees an error`,
+            [
+                generateProblem(
+                    {line: 6, column: 19},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "multiple steps, each contains one word to avoid",
+            `Feature: WordsToAvoid
+  Scenario: multiple steps, each contains one word to avoid
+    Given a feature does have a lot of steps
+    When the user uses the word clicks
+    And also the word "sees"
+    Then the user should sees an error`,
+            [
+                generateProblem(
+                    {line: 4, column: 33},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 5, column: 24},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 6, column: 26},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "multiple steps, each contains multiple words to avoid",
+            `Feature: WordsToAvoid
+  Scenario: multiple steps, each contains one word to avoid
+    Given a feature does have a lot of steps
+    When the user sees and clicks
+    And also clicks and "sees" & sees & clicks
+    Then the user should sees an error and clicks it and clicks it & sees`,
+            [
+                generateProblem(
+                    {line: 4, column: 19},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 4, column: 28},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 5, column: 14},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 5, column: 26},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 5, column: 34},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 5, column: 41},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 6, column: 26},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 6, column: 44},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 6, column: 58},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 6, column: 70},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "words to avoid in different quotes",
+            `Feature: WordsToAvoid
+  Scenario: multiple steps, each contains one word to avoid in quotes
+    Given a feature does have a lot of steps
+    When the user uses the word 'clicks'
+    And also the word "sees"
+    And also the word 'sees"
+    And also the word ”clicks"
+    And also the word ”clicks”
+    And also the word ”clicks“ in other quotes
+    Then the user should “sees“ an error`,
+            [
+                generateProblem(
+                    {line: 4, column: 34},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 5, column: 24},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 6, column: 24},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 7, column: 24},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 8, column: 24},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 9, column: 24},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 10, column: 27},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+            ],
+        ],
+        [
+            "words to avoid in different positions in the sentence",
+            `Feature: WordsToAvoid
+  Scenario: multiple steps, each contains one word to avoid
+    Given sees a feature does have a lot of steps
+    When the user uses the word 'clicks
+    And the user uses the word clicks
+    And "sees also the word sees
+    And sees also the word clicks`,
+            [
+                generateProblem(
+                    {line: 3, column: 11},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 4, column: 34},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 5, column: 32},
+                    "Do not use the word 'clicks'."
+                ),
+                generateProblem(
+                    {line: 6, column: 10},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 6, column: 29},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 7, column: 9},
+                    "Do not use the word 'sees'. Describe how the app behaves, not what the user sees."
+                ),
+                generateProblem(
+                    {line: 7, column: 28},
+                    "Do not use the word 'clicks'."
+                ),
+            ],
+        ],
+        [
+            "words to avoid are only a part of another word",
+            `Feature: WordsToAvoid
+  Scenario: multiple steps, each contains one word to avoid as part of another
+    Given addressees a feature does have a lot of steps
+    When the user uses the word 'indorsees
+    And the user uses the word recognisees
+    And the user recognisees the word
+    And the user seeseessees also the word`,
+            [
+            ],
+        ],
+        [
+            "words to avoid in other parts of the feature file => no error",
+            `Feature: WordsToAvoid click here
+ As a user who sees this feature
+ I Do not want to see any words to be avoided
+
+  Background: the name can also contain bad words like see
+    Given the steps Do not
+
+  Scenario: that has a word to avoid in the name - sees no error
+    Given a feature does have a lot of steps
+    # and also I see some comments
+    When the user runs the 'WordsToAvoid' rule
+    And every step is correct
+    Then no error should be shown
+
+  Scenario Outline: can also contain bad words like click
+    Given the steps Do not
+    Examples:
+    |A|
+    |B|`,
+            [
+            ],
+        ],
+    ];
+}
+
+module.exports = {
+    generateProblem,
+    getTestData,
+};

--- a/tests/lib/rules/words_to_avoid.test.js
+++ b/tests/lib/rules/words_to_avoid.test.js
@@ -1,0 +1,97 @@
+const {
+    getTestData,
+} = require("../../__fixtures__/Rules/words_to_avoid/fixture");
+const WordsToAvoid = require("../../../lib/rules/words_to_avoid");
+const {Linter} = require("../../../lib/linter");
+
+describe("Words To Avoid rule", () => {
+
+    describe("config", () => {
+        test("empty list",  () => {
+            const config = {
+                type: "error",
+            };
+            const linter = new Linter();
+            const ast = linter.parseAst("Feature: \nScenario: empty list\nWhen there is nothing in the list");
+            const problems = WordsToAvoid.run(ast, config);
+
+            expect(problems.length).toEqual(0);
+        });
+        test("list with one item, but without an error message", () => {
+            const config = {
+                type: "error",
+                option: [[["seen"]]],
+            };
+            const linter = new Linter();
+            const ast = linter.parseAst("Feature: \nScenario: empty list\nWhen there is no error in the list\nBut a bad word seen");
+            const problems = WordsToAvoid.run(ast, config);
+
+            expect(problems.length).toEqual(1);
+            expect(problems[0].message).toEqual("Do not use the word 'seen'.");
+        });
+        test("list with multiple items, but without an error message",  () => {
+            const config = {
+                type: "error",
+                option: [[["seen"], ["list"]]],
+            };
+            const linter = new Linter();
+            const ast = linter.parseAst("Feature: \nScenario: empty list\nWhen there is no error in the list\nBut a bad word seen");
+            const problems = WordsToAvoid.run(ast, config);
+
+            expect(problems.length).toEqual(2);
+            expect(problems[0].message).toEqual("Do not use the word 'list'.");
+            expect(problems[1].message).toEqual("Do not use the word 'seen'.");
+        });
+        test("list with multiple items, but only one with an error message",  () => {
+            const config = {
+                type: "error",
+                option: [[["seen", "Describe how the app behaves, not what the user sees."], ["list"]]],
+            };
+            const linter = new Linter();
+            const ast = linter.parseAst("Feature: \nScenario: empty list\nWhen there is no error in the list\nBut a bad word seen");
+            const problems =  WordsToAvoid.run(ast, config);
+
+            expect(problems.length).toEqual(2);
+            expect(problems[0].message).toEqual("Do not use the word 'list'.");
+            expect(problems[1].message).toEqual("Do not use the word 'seen'. Describe how the app behaves, not what the user sees.");
+        });
+
+    });
+
+    describe("invalid ast", () => {
+        const config = {
+            type: "error",
+        };
+        it.each([[undefined], [null], [""], [{}]])(
+            "'%s': should return undefined",
+            (ast) => {
+                const problems = WordsToAvoid.run(ast, config);
+                expect(problems).toEqual([]);
+            }
+        );
+    });
+
+    describe("different cases using words 'sees' and 'clicks'", () => {
+        const config = {
+            type: "error",
+            option: [[["sees", "Describe how the app behaves, not what the user sees."], ["clicks"]]],
+        };
+        const testData = getTestData();
+
+        it.each(testData)("%s", (_, text, expectedProblems) => {
+            const linter = new Linter();
+            const ast = linter.parseAst(text);
+            const problems = WordsToAvoid.run(ast, config);
+
+            expect(problems.length).toEqual(expectedProblems.length);
+            problems.forEach((problem, index) => {
+                expect(problem.location).toEqual(
+                    expectedProblems[index].location
+                );
+                expect(problem.message).toEqual(
+                    expectedProblems[index].message
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Description
This feature allows defining a list of words that should be avoided in the steps.

## Motivation and Context
We might want to avoid and flag certain key-words in the steps like "click", "see", etc.

## How Has This Been Tested?
- unit tests
- test cases of OpenTalk

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Documentation updated
