### PR TITLE
chore: Add Docker support for Gherlint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+node_modules
+coverage
+.yarn/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+COPY .yarnrc.yml ./
+COPY .yarn ./.yarn
+
+RUN corepack enable
+RUN yarn install --immutable
+
+COPY . .
+
+ENTRYPOINT ["node", "./bin/gherlint.js"]

--- a/README.md
+++ b/README.md
@@ -137,3 +137,34 @@ If you want to contribute by adding a new rule, please follow the [Adding New Ru
 ## License
 
 [MIT License](LICENSE)
+
+## Docker Support
+
+Gherlint can be run using Docker without installing dependencies locally.
+
+### Build Image
+
+```
+docker build -t gherlint .
+```
+
+### Lint Feature Files
+```
+docker run --rm \
+  -v /path/to/project:/project \
+  gherlint \
+  /project/features \
+  -c /project/.gherlintrc.json
+```
+
+### Fix Feature Files
+```
+docker run --rm \
+  -v /path/to/project:/project \
+  gherlint \
+  --fix \
+  /project/features \
+  -c /project/.gherlintrc.json
+  ```
+  
+The Docker container runs the Gherlint CLI, uses mounted project files as input, reports lint errors, and applies available fixes with --fix.


### PR DESCRIPTION
<!--
Thanks for submitting a change to GherLint!

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of gherlint.

Please set the following labels:

- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description

This PR adds Docker support for Gherlint, allowing the CLI to be executed in a containerized environment.

The Docker image accepts project feature files and a Gherlint configuration file as inputs, and outputs linting errors or applies supported automatic fixes using --fix.

Changes:
Added a Dockerfile to build a reusable Gherlint Docker image.
Added a .dockerignore file to reduce the Docker build context and image size.
Added Docker usage documentation to the README.md, including:
Building the Docker image
Running Gherlint to lint feature files
Running Gherlint with --fix to apply supported automatic fixes
## Related Issue
- Fixes <issue_link>
- Part of <issue_link>

## Motivation and Context

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Tests only (no source changes)
- [ ] Documentation only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Documentation updated
